### PR TITLE
CTP-4184 Enable staff only alerts

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13
+        image: postgres:14
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'

--- a/block_alerts.php
+++ b/block_alerts.php
@@ -84,11 +84,8 @@ class block_alerts extends block_base {
     public static function is_teacher(): bool {
         global $DB, $USER;
 
-        // System level roles.
-        $context = context_system::instance();
-        $roles = get_user_roles($context, $USER->id);
         // Check for manager or coursecreator role.
-        foreach ($roles as $role) {
+        foreach (get_user_roles(context_system::instance()) as $role) {
             if ($role->shortname === 'manager' || $role->shortname === 'coursecreator') {
                 return true;
             }

--- a/block_alerts.php
+++ b/block_alerts.php
@@ -78,7 +78,7 @@ class block_alerts extends block_base {
     }
 
     /**
-     * Return if user has archetype editingteacher.
+     * Return if user has archetype editingteacher or system manager/coursecreator role.
      *
      */
     public static function is_teacher(): bool {

--- a/block_alerts.php
+++ b/block_alerts.php
@@ -83,6 +83,17 @@ class block_alerts extends block_base {
      */
     public static function is_teacher(): bool {
         global $DB, $USER;
+
+        // System level roles.
+        $context = context_system::instance();
+        $roles = get_user_roles($context, $USER->id);
+        // Check for manager or coursecreator role.
+        foreach ($roles as $role) {
+            if ($role->shortname === 'manager' || $role->shortname === 'coursecreator') {
+                return true;
+            }
+        }
+
         // Get id's from role where archetype is editingteacher.
         $roles = $DB->get_fieldset('role', 'id', ['archetype' => 'editingteacher']);
 
@@ -103,10 +114,8 @@ class block_alerts extends block_base {
      */
     public function fetch_alert(): array {
         // Staff only check.
-        if (get_config('block_alerts', 'staffonly')) {
-            if (!self::is_teacher()) {
-                return []; // Don't ouput for learners.
-            }
+        if (get_config('block_alerts', 'staffonly') && !self::is_teacher()) {
+            return [];
         }
 
         // Template data for mustache.

--- a/block_alerts.php
+++ b/block_alerts.php
@@ -114,7 +114,6 @@ class block_alerts extends block_base {
 
         // Get alert content.
         $alert = new stdClass();
-        $alert->staffonly = get_config('block_alerts', 'staffonly');
         $alert->title = get_config('block_alerts', 'title');
         $alert->description = get_config('block_alerts', 'description');
         $alert->link = get_config('block_alerts', 'link');

--- a/block_alerts.php
+++ b/block_alerts.php
@@ -77,7 +77,7 @@ class block_alerts extends block_base {
         return $this->content;
     }
 
-     /**
+    /**
      * Return if user has archetype editingteacher.
      *
      */
@@ -104,9 +104,9 @@ class block_alerts extends block_base {
     public function fetch_alert(): array {
         // Staff only check.
         if (get_config('block_alerts', 'staffonly')) {
-           if (!self::is_teacher()) {
-            return []; // Don't ouput for learners.
-           }
+            if (!self::is_teacher()) {
+                return []; // Don't ouput for learners.
+            }
         }
 
         // Template data for mustache.

--- a/lang/en/block_alerts.php
+++ b/lang/en/block_alerts.php
@@ -34,5 +34,5 @@ $string['linktext'] = 'Link text';
 $string['linktext_help'] = 'A meaningful link title. Do not use inaccessible link text such as "click here" or "read more".';
 $string['pluginname'] = 'Alerts';
 $string['privacy:metadata'] = 'Alerts does not store any personal data.';
-$string['staffonly'] = "Staff only";
+$string['staffonly'] = "Only visible to staff";
 $string['title'] = 'Title';

--- a/lang/en/block_alerts.php
+++ b/lang/en/block_alerts.php
@@ -34,4 +34,5 @@ $string['linktext'] = 'Link text';
 $string['linktext_help'] = 'A meaningful link title. Do not use inaccessible link text such as "click here" or "read more".';
 $string['pluginname'] = 'Alerts';
 $string['privacy:metadata'] = 'Alerts does not store any personal data.';
+$string['staffonly'] = "Staff only";
 $string['title'] = 'Title';

--- a/settings.php
+++ b/settings.php
@@ -40,7 +40,7 @@ if ($hassiteconfig) {
             '',
             $default,
             PARAM_RAW,
-            '140'
+            '60'
         );
         $settings->add($setting);
 
@@ -50,7 +50,7 @@ if ($hassiteconfig) {
             get_string('description_help', 'block_alerts'),
             $default,
             PARAM_RAW,
-            '140'
+            '60'
         );
         $settings->add($setting);
 
@@ -60,6 +60,7 @@ if ($hassiteconfig) {
             get_string('link_help', 'block_alerts'),
             $default,
             PARAM_RAW,
+            '60'
         );
         $settings->add($setting);
 
@@ -68,7 +69,8 @@ if ($hassiteconfig) {
             get_string('linktext', 'block_alerts'),
             get_string('linktext_help', 'block_alerts'),
             $default,
-            PARAM_RAW
+            PARAM_RAW,
+            '60'
         );
         $settings->add($setting);
 

--- a/settings.php
+++ b/settings.php
@@ -29,12 +29,18 @@ if ($hassiteconfig) {
 
         $default = '';
 
+        // Staff only.
+        $setting = new admin_setting_configcheckbox('block_alerts/staffonly',
+            get_string('staffonly', 'block_alerts'), '', 0);
+        $settings->add($setting);
+
         // Title.
         $setting = new admin_setting_configtext('block_alerts/title',
             get_string('title', 'block_alerts'),
             '',
             $default,
-            PARAM_RAW
+            PARAM_RAW,
+            '140'
         );
         $settings->add($setting);
 
@@ -43,7 +49,8 @@ if ($hassiteconfig) {
             get_string('description', 'block_alerts'),
             get_string('description_help', 'block_alerts'),
             $default,
-            PARAM_RAW
+            PARAM_RAW,
+            '140'
         );
         $settings->add($setting);
 
@@ -52,7 +59,7 @@ if ($hassiteconfig) {
             get_string('link', 'block_alerts'),
             get_string('link_help', 'block_alerts'),
             $default,
-            PARAM_RAW
+            PARAM_RAW,
         );
         $settings->add($setting);
 

--- a/templates/content.mustache
+++ b/templates/content.mustache
@@ -28,7 +28,7 @@
 }}
 
 <div role="alert" class="alert alert-info px-2 border-info d-flex align-items-center"
-  style="border: none; border-left: .5rem solid;" >
+  style="border: none; border-left: .3rem solid;" >
     <!-- Alert icon. -->
     <i class="fa-solid fa-triangle-exclamation fa-2xl text-primary ml-2"></i>
     <!-- Alert content. -->

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023062600;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024121200;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->release   = '1.0';
 $plugin->maturity  = MATURITY_ALPHA;
 $plugin->requires  = 2019051100;        // Requires this Moodle version.


### PR DESCRIPTION
Add a checkbox to only show alert to staff when not relevant to learners.